### PR TITLE
Remove extraneous console log

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ var revTimeStamp = function(options){
         options.mode="timestamp";
     if(!options.hasOwnProperty("revision"))
         options.revision=0;
-    console.log(options.mode);
     if(!file)
         throw new PluginError('gulp-rev-append', 'Missing file option for gulp-rev-append.');
     if(!file.contents)


### PR DESCRIPTION
When running build I get a ton of "timestamp" logs in my build which creates a bunch of unnecessary noise. This removes that.