### PR TITLE
replace gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var Buffer = require('buffer').Buffer;
-var gutil = require('gulp-util');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var map = require('event-stream').map;
 
 var FILE_DECL = /(?:href=|src=|url\()['|"]([^\s>"']+?)\?rev=([^\s>"']+?)['|"]/gi;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "event-stream": "^3.1.0",
-    "gulp-util": "^2.2.14"
+    "plugin-error": "^1.0.1"
   },
   "author": "CVS",
   "license": "ISC"


### PR DESCRIPTION
```
npm WARN deprecated gulp-util@2.2.20: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
```